### PR TITLE
Bumped version number to match Curseforge mod page

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -11,7 +11,7 @@ issueTrackerURL="http://my.issue.tracker/" #optional
 
 modId="ccam" #mandatory
 
-version="1.0.1" #mandatory
+version="1.2.5" #mandatory
 
 displayName="Colt's Cosmetic Armour Mod" #mandatory
 


### PR DESCRIPTION
The Curseforge mod page lists this mod as version 1.2.5, However, a lot of in-game editors and launchers will still refer to this mod as the version listed in this resource file.

So I just bumped the version to match the release number.